### PR TITLE
QUAl-216 refactor elastic ioc registry

### DIFF
--- a/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
+++ b/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
@@ -122,7 +122,8 @@
     <Compile Include="Caching\AzureRedisCacheService.cs" />
     <Compile Include="Exceptions\InfrastructureException.cs" />
     <Compile Include="Factories\SqlDatabaseService.cs" />
-    <Compile Include="InfrastructureRegistry.cs" />
+    <Compile Include="Ioc\ElasticClientRegistry.cs" />
+    <Compile Include="Ioc\InfrastructureRegistry.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\CachedTrainingDetailService.cs" />
     <Compile Include="Services\CreateApprenticeshipService.cs" />

--- a/src/Esfa.Vacancy.Infrastructure/Ioc/ElasticClientRegistry.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Ioc/ElasticClientRegistry.cs
@@ -1,0 +1,39 @@
+﻿using Esfa.Vacancy.Domain.Constants;
+using Esfa.Vacancy.Domain.Interfaces;
+using Esfa.Vacancy.Infrastructure.Settings;
+using SFA.DAS.Elastic;
+using SFA.DAS.VacancyServices.Search;
+using System;
+
+namespace Esfa.Vacancy.Infrastructure.Ioc
+{
+    public sealed class ElasticClientRegistry : StructureMap.Registry
+    {
+        public ElasticClientRegistry()
+            : this(new AppConfigSettingsProvider(new MachineSettings()))
+        {
+        }
+
+        public ElasticClientRegistry(IProvideSettings _provideSettings)
+        {
+            var username = _provideSettings.GetNullableSetting(ApplicationSettingKeys.ElasticUsernameKey);
+            var password = _provideSettings.GetNullableSetting(ApplicationSettingKeys.ElasticPasswordKey);
+            var indexName = _provideSettings.GetSetting(ApplicationSettingKeys.ApprenticeshipIndexAliasKey);
+
+            ElasticClientConfiguration elasticConfig;
+#if DEBUG
+            var hostUrl = _provideSettings.GetSetting(ApplicationSettingKeys.VacancySearchUrlKey);
+
+            elasticConfig = string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password)
+                ? new ElasticClientConfiguration(new Uri(hostUrl))
+                : new ElasticClientConfiguration(new Uri(hostUrl), username, password);
+#else
+            var cloudId = _provideSettings.GetSetting(ApplicationSettingKeys.ElasticCloudIdKey);
+            elasticConfig = new ElasticClientConfiguration(cloudId, username, password);
+#endif
+            For<ElasticClientConfiguration>().Use(elasticConfig);
+            For<IElasticClientFactory>().Use<ElasticClientFactory>();
+            For<IApprenticeshipSearchClient>().Use<ApprenticeshipSearchClient>().Ctor<string>("indexName").Is(indexName);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Infrastructure/Ioc/InfrastructureRegistry.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Ioc/InfrastructureRegistry.cs
@@ -8,11 +8,9 @@ using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Caching;
 using Esfa.Vacancy.Infrastructure.Services;
 using Esfa.Vacancy.Infrastructure.Settings;
-using SFA.DAS.Elastic;
 using SFA.DAS.NLog.Logger;
-using SFA.DAS.VacancyServices.Search;
 
-namespace Esfa.Vacancy.Infrastructure
+namespace Esfa.Vacancy.Infrastructure.Ioc
 {
     public sealed class InfrastructureRegistry : StructureMap.Registry
     {
@@ -40,31 +38,8 @@ namespace Esfa.Vacancy.Infrastructure
                 .Ctor<ITrainingDetailService>().Is<TrainingDetailService>();
 
             RegisterCreateApprenticeshipService();
-
-            RegisterElasticsearchClient();
         }
 
-        private void RegisterElasticsearchClient()
-        {
-            var username = _provideSettings.GetNullableSetting(ApplicationSettingKeys.ElasticUsernameKey);
-            var password = _provideSettings.GetNullableSetting(ApplicationSettingKeys.ElasticPasswordKey);
-            var indexName = _provideSettings.GetSetting(ApplicationSettingKeys.ApprenticeshipIndexAliasKey);
-
-            ElasticClientConfiguration elasticConfig;
-#if DEBUG
-            var hostUrl = _provideSettings.GetSetting(ApplicationSettingKeys.VacancySearchUrlKey);
-
-            elasticConfig = string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password) 
-                ? new ElasticClientConfiguration(new Uri(hostUrl))
-                : new ElasticClientConfiguration(new Uri(hostUrl), username, password);
-#else
-            var cloudId = _provideSettings.GetSetting(ApplicationSettingKeys.ElasticCloudIdKey);
-            elasticConfig = new ElasticClientConfiguration(cloudId, username, password);
-#endif
-            For<ElasticClientConfiguration>().Use(elasticConfig);
-            For<IElasticClientFactory>().Use<ElasticClientFactory>();
-            For<IApprenticeshipSearchClient>().Use<ApprenticeshipSearchClient>().Ctor<string>("indexName").Is(indexName);
-        }
 
         private IDictionary<string, object> GetProperties()
         {

--- a/src/Esfa.Vacancy.Manage.Api/DependencyResolution/IoC.cs
+++ b/src/Esfa.Vacancy.Manage.Api/DependencyResolution/IoC.cs
@@ -15,7 +15,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-using Esfa.Vacancy.Infrastructure;
+using Esfa.Vacancy.Infrastructure.Ioc;
 using StructureMap;
 
 namespace Esfa.Vacancy.Manage.Api.DependencyResolution {

--- a/src/Esfa.Vacancy.Register.Api/DependencyResolution/IoC.cs
+++ b/src/Esfa.Vacancy.Register.Api/DependencyResolution/IoC.cs
@@ -16,7 +16,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 
-using Esfa.Vacancy.Infrastructure;
+using Esfa.Vacancy.Infrastructure.Ioc;
 using StructureMap;
 
 namespace Esfa.Vacancy.Register.Api.DependencyResolution
@@ -30,6 +30,8 @@ namespace Esfa.Vacancy.Register.Api.DependencyResolution
                 c.AddRegistry<DefaultRegistry>();
                 c.AddRegistry<InfrastructureRegistry>();
                 c.AddRegistry<WebRegistry>();
+                c.AddRegistry<ElasticClientRegistry>();
+
             });
         }
     }

--- a/src/Esfa.Vacancy.UnitTests/Shared/Infrastructure/GivenStructureMapRegistry.cs
+++ b/src/Esfa.Vacancy.UnitTests/Shared/Infrastructure/GivenStructureMapRegistry.cs
@@ -1,6 +1,7 @@
 ﻿using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure;
+using Esfa.Vacancy.Infrastructure.Ioc;
 using Esfa.Vacancy.Infrastructure.Services;
 using Moq;
 using NUnit.Framework;


### PR DESCRIPTION
The elastic registry was added to the infrastructure registry but this is not required for Manage API so separated elastic registry in its own class and only used it in the Register api where it is needed. 