### PR TITLE
Added ipSecurityRestrictions object for Manage API and Manage Sandbox API

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -457,6 +457,9 @@
                     },
                     "appKind": {
                         "value": "api"
+                    },
+                    "ipSecurityRestrictions": {
+                        "value": "[parameters('ipSecurityRestrictions')]"
                     }
                 }
             }
@@ -539,6 +542,9 @@
                     },
                     "appKind": {
                         "value": "api"
+                    },
+                    "ipSecurityRestrictions": {
+                        "value": "[parameters('ipSecurityRestrictions')]"
                     }
                 }
             }


### PR DESCRIPTION
Added the `ipSecurityRestrictions` object to ARM template for the Manage API and Manage Sandbox API App Service resource deployments in preparation for change to network restrict.